### PR TITLE
fix(build): emit flat dist/index.js to match published manifest (Sev 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.tsbuildinfo
 .DS_Store
 coverage/
+*.tgz

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { Command } from "commander";
 import { initCommand } from "./commands/init.js";
 import { runCommand } from "./commands/run.js";
@@ -6,10 +7,27 @@ import { statusCommand } from "./commands/status.js";
 import { logsCommand } from "./commands/logs.js";
 import { destroyCommand } from "./commands/destroy.js";
 
+// Resolve package.json relative to this module so the CLI version stays in
+// lockstep with package.json instead of drifting silently. Bin runs from
+// dist/cli/bin.js → ../../package.json. dev (tsx) runs from cli/index.ts
+// → ../package.json. Try both so the same file works either way.
+function readPackageVersion(): string {
+  for (const rel of ["../package.json", "../../package.json"]) {
+    try {
+      const url = new URL(rel, import.meta.url);
+      const pkg = JSON.parse(readFileSync(url, "utf8")) as { version?: string };
+      if (pkg.version) return pkg.version;
+    } catch {
+      /* try next */
+    }
+  }
+  return "unknown";
+}
+
 export const program = new Command()
   .name("agento-sdk")
   .description("Agent OS in Cloud Sandboxes — OpenFang + E2B + Claude Code")
-  .version("0.1.0");
+  .version(readPackageVersion());
 
 program.addCommand(initCommand);
 program.addCommand(runCommand);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agento-nexus/sdk",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Agent OS in Cloud Sandboxes — OpenFang + E2B + Claude Code",
   "type": "module",
   "main": "./dist/index.js",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "cli/bin.ts"],
+  // Object form pins each entry to a flat output path. The previous array form
+  // (["src/index.ts", "cli/bin.ts"]) preserved source paths in dist/, so the
+  // build emitted dist/src/index.js and dist/cli/bin.js — but package.json
+  // declares main:"./dist/index.js" and bin:"./dist/cli/bin.js", so every
+  // `npm install @agento-nexus/sdk` followed by `import` resolved to a path
+  // that didn't exist and threw ERR_MODULE_NOT_FOUND on the first line.
+  // See PR description for the npm-side trace.
+  entry: {
+    index: "src/index.ts",
+    "cli/bin": "cli/bin.ts",
+  },
   format: ["esm"],
   dts: true,
   clean: true,


### PR DESCRIPTION
## TL;DR

`@agento-nexus/sdk@0.1.1` is broken on npm: every `npm install` followed by an `import` from the package throws `ERR_MODULE_NOT_FOUND` on the first line. Bumps to `0.1.2` with a working build. Discovered during `/devex-review` Phase 2.

## Repro (against currently-published 0.1.1)

```bash
npm install @agento-nexus/sdk@0.1.1
node -e "import('@agento-nexus/sdk').then(s => console.log(Object.keys(s)))"
# → Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/index.js'
```

## Root cause

`tsup.config.ts` used the array form of `entry`:

```ts
entry: ["src/index.ts", "cli/bin.ts"]
```

With the array form, tsup preserves source paths in `dist/`, so the build emitted `dist/src/index.js` and `dist/cli/bin.js`. But `package.json` declares:

```json
"main":  "./dist/index.js",
"types": "./dist/index.d.ts",
"exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } }
```

Both pointers were dead. Every consumer's first import fails.

Weekly downloads at time of discovery: 4 — so blast radius is small but the impact-per-attempt is total.

## Fix

1. **`tsup.config.ts`** — switch entry to the object form, which pins each entry to a flat output path:
   ```ts
   entry: { index: "src/index.ts", "cli/bin": "cli/bin.ts" }
   ```
   Output is now `dist/index.js`, `dist/index.d.ts`, `dist/cli/bin.js`, `dist/cli/bin.d.ts` — matching the published manifest.

2. **`cli/index.ts`** — read `.version()` from `package.json` at runtime instead of the hardcoded `"0.1.0"` string. The hardcode had already drifted — `agento-sdk --version` printed `0.1.0` after 0.1.1 shipped. Uses `fs.readFileSync(new URL("../package.json", import.meta.url))` with a fallback for the dev/tsx layout where the depth differs.

3. **`package.json`** — bump `0.1.1` → `0.1.2` since `0.1.1` is published-broken.

4. **`.gitignore`** — ignore `*.tgz` from local `npm pack` dogfood.

## Verification (all done locally)

- [x] `npm run build` → emits `dist/{index.js, index.d.ts, cli/bin.js, cli/bin.d.ts}` (no more `dist/src/`)
- [x] `npm test` → 28/28 passing
- [x] `npm run typecheck` → clean
- [x] `npm pack` + fresh `npm install ./agento-nexus-sdk-0.1.2.tgz` in /tmp:
  ```
  import * as sdk from '@agento-nexus/sdk'
  Object.keys(sdk).sort()
  → ['ClaudeBridge', 'FangBox', 'Fleet', 'Logger', 'OpenFangClient',
     'OpenFangError', 'TemplateBuilder', 'TypedEmitter',
     'createFangBox', 'retry']
  ```
- [x] `agento-sdk --version` → `0.1.2` (was reporting stale `0.1.0`)
- [ ] Reviewed locally
- [ ] Publish 0.1.2 to npm post-merge

## Followups (separate)

- The `node_modules/openapi-fetch/dist/cjs/index.d.cts` types warning a TS consumer sees with `skipLibCheck: false`. Most consumer projects default `skipLibCheck: true` so this is not a blocker; tracked separately.
- More Phase 2 SDK findings (errors, docs walkthrough, CLI ergonomics) coming as separate issues / PRs.

## Out of scope

- `package-lock.json` regenerated when I cleaned `node_modules` for fresh install. Not included to keep the PR tight; can land as a separate cleanup.